### PR TITLE
Ddv response mod

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { decodeNodePublic } from 'ripple-address-codec'
 import { verify } from 'ripple-keypairs'
 
@@ -22,6 +21,7 @@ interface Validator {
  * @param manifest - The signed manifest that contains the validator's domain.
  * @returns A verified, message, and the verified manifest.
  */
+// eslint-disable-next-line max-lines-per-function -- Necessary use of extra lines.
 async function verifyValidatorDomain(
   manifest: string | ManifestParsed | StreamManifest,
 ): Promise<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ interface Validator {
  */
 // eslint-disable-next-line max-lines-per-function -- Necessary use of extra lines.
 async function verifyValidatorDomain(
-  manifest: string | ManifestParsed | StreamManifest,
+  manifest: string | ManifestParsed | StreamManifest | Manifest,
 ): Promise<{
   verified: boolean
   verified_manifest_signature: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { decodeNodePublic } from 'ripple-address-codec'
 import { verify } from 'ripple-keypairs'
 
@@ -25,6 +26,7 @@ async function verifyValidatorDomain(
   manifest: string | ManifestParsed | StreamManifest,
 ): Promise<{
   verified: boolean
+  verified_manifest_signature: boolean
   message: string
   manifest?: Manifest
 }> {
@@ -37,6 +39,7 @@ async function verifyValidatorDomain(
   if (!verifyManifestSignature(normalizedManifest)) {
     return {
       verified: false,
+      verified_manifest_signature: false,
       message: 'Cannot verify manifest signature',
       manifest: normalizedManifest,
     }
@@ -45,6 +48,7 @@ async function verifyValidatorDomain(
   if (domain === undefined) {
     return {
       verified: false,
+      verified_manifest_signature: true,
       message: 'Manifest does not contain a domain',
       manifest: normalizedManifest,
     }
@@ -54,6 +58,7 @@ async function verifyValidatorDomain(
   if (!validatorInfo.VALIDATORS) {
     return {
       verified: false,
+      verified_manifest_signature: true,
       message: 'Invalid .toml file',
       manifest: normalizedManifest,
     }
@@ -68,6 +73,7 @@ async function verifyValidatorDomain(
   if (validators.length === 0) {
     return {
       verified: false,
+      verified_manifest_signature: true,
       message: '.toml file does not have matching public key',
       manifest: normalizedManifest,
     }
@@ -80,6 +86,7 @@ async function verifyValidatorDomain(
 
     const failedToVerify = {
       verified: false,
+      verified_manifest_signature: true,
       message: `Invalid attestation, cannot verify ${domain}`,
       manifest: normalizedManifest,
     }
@@ -98,6 +105,7 @@ async function verifyValidatorDomain(
 
   return {
     verified: true,
+    verified_manifest_signature: true,
     message: `${domain} has been verified`,
     manifest: normalizedManifest,
   }

--- a/test/validate-domain.test.ts
+++ b/test/validate-domain.test.ts
@@ -9,7 +9,7 @@ import payIdMayurResponse from './fixtures/payid-mayur.json'
 import rabbitKickResponse from './fixtures/rabbitkick.json'
 import noKey from './fixtures/toml-no-matching-pubkey.json'
 
-const rabbitKickManifiest =
+const rabbitKickManifest =
   '240000007B7121EDA54C85F91219FD259134B6B126AD64AE7204B81DD4052510657E1A5697246AD27321032F7ACF6D67C42C9C898F576F92FE4638EB6C88D0DC7F6710AF00ED6BF50D97D676473045022100BE0B2E6071AED53C19A76BDC6EDE1A351C35343AA7CF917587F93C9D85C5A7B702207135F72654DC3AD70FE8A4DEB128965268A312DFB3E9A7C68BA8E9A8931F4285770F7261626269746B69636B2E636C7562701240C4FF2A6D277D24DEFB1C1EDF67285171EA02DC035FEF6216DEE41019CE41611AD4430AF59938DC505E538CCF669D521AC2A456C3805FE3CA85BB10B2A691B50B'
 const rabbitKickParsed = {
   Sequence: 123,
@@ -115,8 +115,9 @@ describe('Verifies domains', () => {
       .get('/.well-known/xrp-ledger.toml')
       .reply(200, rabbitKickResponse.response)
 
-    expect(await verifyValidatorDomain(rabbitKickManifiest)).to.eql({
+    expect(await verifyValidatorDomain(rabbitKickManifest)).to.eql({
       verified: true,
+      verified_manifest_signature: true,
       message: 'rabbitkick.club has been verified',
       manifest: rabbitKickManifestResponse,
     })
@@ -127,6 +128,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(rabbitKickParsed)).to.eql({
       verified: true,
+      verified_manifest_signature: true,
       message: 'rabbitkick.club has been verified',
       manifest: rabbitKickManifestResponse,
     })
@@ -137,6 +139,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(rabbitKickStreamManifest)).to.eql({
       verified: true,
+      verified_manifest_signature: true,
       message: 'rabbitkick.club has been verified',
       manifest: rabbitKickManifestResponse,
     })
@@ -149,6 +152,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(mayursManifest)).to.eql({
       verified: true,
+      verified_manifest_signature: true,
       message: 'payid.mayurbhandary.com has been verified',
       manifest: mayursManifestResponse,
     })
@@ -159,6 +163,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(mayursParsed)).to.eql({
       verified: true,
+      verified_manifest_signature: true,
       message: 'payid.mayurbhandary.com has been verified',
       manifest: mayursManifestResponse,
     })
@@ -168,6 +173,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(mayursStreamManifest)).to.eql({
       verified: true,
+      verified_manifest_signature: true,
       message: 'payid.mayurbhandary.com has been verified',
       manifest: mayursManifestResponse,
     })
@@ -176,18 +182,21 @@ describe('Verifies domains', () => {
   it('no domain manifest', async () => {
     expect(await verifyValidatorDomain(noDomainStr)).to.eql({
       verified: false,
+      verified_manifest_signature: true,
       message: 'Manifest does not contain a domain',
       manifest: noDomainResponseManifest,
     })
 
     expect(await verifyValidatorDomain(noDomainParsed)).to.eql({
       verified: false,
+      verified_manifest_signature: true,
       message: 'Manifest does not contain a domain',
       manifest: noDomainResponseManifest,
     })
 
     expect(await verifyValidatorDomain(noDomainStreamManifest)).to.eql({
       verified: false,
+      verified_manifest_signature: true,
       message: 'Manifest does not contain a domain',
       manifest: noDomainResponseManifest,
     })
@@ -200,6 +209,7 @@ describe('Verifies domains', () => {
     }
     expect(await verifyValidatorDomain(invalid)).to.eql({
       verified: false,
+      verified_manifest_signature: false,
       message: 'Cannot verify manifest signature',
       manifest: {
         domain: 'rabbitkick.club',
@@ -220,6 +230,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(mayursManifest)).to.eql({
       verified: false,
+      verified_manifest_signature: true,
       message: 'Invalid .toml file',
       manifest: mayursManifestResponse,
     })
@@ -232,6 +243,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(mayursManifest)).to.eql({
       verified: false,
+      verified_manifest_signature: true,
       message: '.toml file does not have matching public key',
       manifest: mayursManifestResponse,
     })
@@ -244,6 +256,7 @@ describe('Verifies domains', () => {
 
     expect(await verifyValidatorDomain(mayursManifest)).to.eql({
       verified: false,
+      verified_manifest_signature: true,
       message: 'Invalid attestation, cannot verify payid.mayurbhandary.com',
       manifest: mayursManifestResponse,
     })


### PR DESCRIPTION
## High Level Overview of Change
Adds another property to the ddv response format including whether manifest signature was verified `verified_manifest_signature`

Related PR: https://github.com/xpring-eng/validator-history-service/pull/12/files

